### PR TITLE
fix(file-naming): sync Frappe File record after physical file move

### DIFF
--- a/my_app/helper/file_naming.py
+++ b/my_app/helper/file_naming.py
@@ -7,7 +7,13 @@ import frappe
 def file_retitling(original_file_url: str, folder_suffix: str, name: str) -> dict:
 	"""
 	Renames the uploaded video filename using the generated name for that video_info record,
-	and returns file metadata as a dictionary.
+	moves it into a sub-folder, and returns file metadata as a dictionary.
+
+	Also updates the Frappe File doctype record so that Frappe's internal file
+	management stays in sync with the new physical location. Without this step,
+	the old File record retains the original (now broken) file_url, causing
+	Frappe to treat the attachment as missing and potentially re-upload the file
+	on the next save — resulting in duplicate entries under /files/original/.
 
 	Args:
 	    original_file_url (str): The URL to the original uploaded file (e.g., /files/sample123.mp4).
@@ -38,6 +44,16 @@ def file_retitling(original_file_url: str, folder_suffix: str, name: str) -> dic
 	shutil.move(original_path, new_path)
 
 	new_file_url_doc = f"/files/{folder_suffix}/{new_filename}"
+
+	# Sync the Frappe File doctype record to the new location.
+	# shutil.move() updates only the physical file; without updating the File
+	# record, Frappe still holds a reference to the old (now missing) path.
+	# On the next document save Frappe may re-upload the file, producing a
+	# duplicate entry in /files/original/.
+	file_doc_name = frappe.db.get_value("File", {"file_url": original_file_url}, "name")
+	if file_doc_name:
+		frappe.db.set_value("File", file_doc_name, "file_url", new_file_url_doc)
+		frappe.db.commit()
 
 	file_info = {
 		"original_filename": original_filename,


### PR DESCRIPTION
RCA and Fix for Issue #4
file_retitling() used shutil.move() to relocate the uploaded video from /files/<filename> to /files/original/<filename>_<name>, but never updated the corresponding Frappe File doctype record. That record retained the original file_url pointing to the now-missing path.

On subsequent saves of the VideoInfo document, Frappe's file management detects the broken attachment (file_url resolves to a non-existent file) and may re-upload the video, creating a duplicate entry under /files/original/.

Fix: after shutil.move(), look up the File doctype record by the old file_url and update it to the new location with frappe.db.set_value(). This keeps Frappe's internal file registry in sync with the physical filesystem, preventing the orphaned record from triggering re-uploads.

Fixes #4

Its Ready for Review. 
Thanks